### PR TITLE
Add new Issue Template for "Art Request"

### DIFF
--- a/.github/ISSUE_TEMPLATE/art-request.yml
+++ b/.github/ISSUE_TEMPLATE/art-request.yml
@@ -1,6 +1,6 @@
 name: 📖 Art Request
 description: Creates a request for a designer to pick up. Used to ask for blog tile images, graphics for the website, diagrams for presentations, etc.
-labels: [design, task]
+labels: [design, artwork, task]
 body:
 - type: input
   attributes:

--- a/.github/ISSUE_TEMPLATE/art-request.yml
+++ b/.github/ISSUE_TEMPLATE/art-request.yml
@@ -1,0 +1,20 @@
+name: 📖 Art Request
+description: Creates a request for a designer to pick up. Used to ask for blog tile images, graphics for the website, diagrams for presentations, etc.
+labels: [design, task]
+body:
+- type: input
+  attributes:
+    label: Related Issue
+    description: What task or piece of content is this request for?
+    placeholder: '#123'
+- type: textarea
+  attributes:
+    label: Description
+    description: Describe what you need in the artwork, link to any similar images you've seen that you like that may help to inspire the designer, if appropriate.
+    value: |
+      **Considerations:**
+      - Where will the image be displayed/shared, product? blog post? social media? presentaiton? website?
+      
+      **Inspirations:**
+      - <link here>
+      - <link here>

--- a/.github/ISSUE_TEMPLATE/art-request.yml
+++ b/.github/ISSUE_TEMPLATE/art-request.yml
@@ -1,4 +1,4 @@
-name: 📖 Art Request
+name: 🎨 Art Request
 description: Creates a request for a designer to pick up. Used to ask for blog tile images, graphics for the website, diagrams for presentations, etc.
 labels: [design, artwork, task]
 body:

--- a/.github/ISSUE_TEMPLATE/art-request.yml
+++ b/.github/ISSUE_TEMPLATE/art-request.yml
@@ -13,7 +13,7 @@ body:
     description: Describe what you need in the artwork, link to any similar images you've seen that you like that may help to inspire the designer, if appropriate.
     value: |
       **Considerations:**
-      - Where will the image be displayed/shared, product? blog post? social media? presentaiton? website?
+      - Where will the image be displayed/shared, product? blog post? social media? presentation? website?
       
       **Inspirations:**
       - <link here>

--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -1,4 +1,4 @@
-name: Add new issues to the Product Board
+name: Add new issues to the Relevant Boards
 
 on:
   workflow_call:
@@ -6,11 +6,22 @@ on:
       token:
         required: true
 jobs:
-  add-to-project:
+  add-to-project-board:
     name: Add issue to project
     runs-on: ubuntu-latest
     steps:
        - uses: actions/add-to-project@main
          with:
+           project-url: https://github.com/orgs/flowforge/projects/3
+           github-token: ${{ secrets.token }}
+
+  add-to-artwork-board:
+    name: Add art requests to the Artwork board
+    runs-on: ubuntu-latest
+    steps:
+       - uses: actions/add-to-project@main
+         with:
+           labeled: design, artwork
+           label-operator: AND
            project-url: https://github.com/orgs/flowforge/projects/3
            github-token: ${{ secrets.token }}

--- a/labels.json
+++ b/labels.json
@@ -184,5 +184,10 @@
         "color": "D24787",
         "description": "Requires Graphic/UI/UX Design work",
         "name": "design"
+    },
+    {
+        "color": "D24787",
+        "description": "Requires the production of an art asset, e.g. blog tile, diagram, icon",
+        "name": "artwork"
     }
 ]


### PR DESCRIPTION
## Description

- Adds a new issue template such that anyone at FlowForge can create an "Art Request"
- Adds "artwork" label, alongside "design", as this makes it easier to recognise and auto-assign to the "Artwork" board
- Updates Project Board action 

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions

