### PR TITLE
Add requirement to explain why test coverage isn't being added

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,7 +11,7 @@
 <!-- https://flowforge.com/handbook/development/#defining-done -->
 
  - [ ] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
- - [ ] Suitable unit/system level tests have been added and they pass
+ - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
  - [ ] Documentation has been updated
     - [ ] Upgrade instructions
     - [ ] Configuration details


### PR DESCRIPTION
I'd like the FlowForge team so start specifying _why_ test coverage hasn't been added on a particular PR, particularly for regressions. The objective here is to increase our test coverage when there isn't a good reason not to add tests.

Adding it to the pull request template seemed like a good start.

To be clear I feel "I don't have enough time this release" should be considered a valid reason, but we should be capturing this.