### PR TITLE
Add the art request issue template to the content repository

### DIFF
--- a/.github/ISSUE_TEMPLATE/08-art_request.yml
+++ b/.github/ISSUE_TEMPLATE/08-art_request.yml
@@ -1,0 +1,20 @@
+name: 🎨 Art Request
+description: Creates a request for a designer to pick up. Used to ask for blog tile images, graphics for the website, diagrams for presentations, etc.
+labels: [design, artwork, task]
+body:
+- type: input
+  attributes:
+    label: Related Issue
+    description: What task or piece of content is this request for?
+    placeholder: '#123'
+- type: textarea
+  attributes:
+    label: Description
+    description: Describe what you need in the artwork, link to any similar images you've seen that you like that may help to inspire the designer, if appropriate.
+    value: |
+      **Considerations:**
+      - Where will the image be displayed/shared, product? blog post? social media? presentation? website?
+      
+      **Inspirations:**
+      - <link here>
+      - <link here>


### PR DESCRIPTION
## Description

Add the art request issue template.
(I intend to add it to the content repository, but it redirects me [here](https://github.com/flowforge/.github/tree/main/.github/ISSUE_TEMPLATE) when I click the "edit template" link from there).

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

