### PR TITLE
Add marketing to flowforge-repositories.yml

### DIFF
--- a/flowforge-repositories.yml
+++ b/flowforge-repositories.yml
@@ -23,6 +23,7 @@ installer
 node-red
 nodered.snap
 node-red-function-gpt
+marketing
 security
 usage-ping-collector
 website


### PR DESCRIPTION
## Description

Some labels aren't showing when creating an issue in the marketing repository. Adding marketing to the flowforge-repositories.yml should fix it.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

